### PR TITLE
Install dhparam into /opt/nogotofail.

### DIFF
--- a/docs/gce/setup_mitm.sh
+++ b/docs/gce/setup_mitm.sh
@@ -9,6 +9,7 @@ LOG_DIR=/var/log/nogotofail
 # Install the relevant source subtree into $INSTALL_DIR
 mkdir -p $INSTALL_DIR $CONFIG_DIR
 cp -a ../../nogotofail $INSTALL_DIR/
+cp ../../dhparam $INSTALL_DIR/
 chown -R root:root $INSTALL_DIR
 chmod -R go-w $INSTALL_DIR
 


### PR DESCRIPTION
The MiTM daemon is failing without this file because it needs
to load DH parameters from this file for each TLS/SSL connection
being MiTM'd.

Fixes #25.
