### PR TITLE
Properly blackhole IPv6 traffic in GCE + OpenVPN setup.

### DIFF
--- a/docs/gce/build_dnsmasq.sh
+++ b/docs/gce/build_dnsmasq.sh
@@ -16,6 +16,6 @@ rm -f tmp.keyring*
 tar zxvf dnsmasq-$DNSMASQ_VERSION.tar.gz
 cd dnsmasq-$DNSMASQ_VERSION
 patch -p1 < ../dnsmasq-empty-AAAA-replies.patch
-make
-sudo make install
+make PREFIX=/usr
+sudo make install PREFIX=/usr
 cd -

--- a/docs/gce/openvpn.conf
+++ b/docs/gce/openvpn.conf
@@ -7,11 +7,18 @@ topology subnet
 
 # Because GCE doesn't support IPv6 we
 # point clients to our caching DNS server. This server
-# sends empty replies for queries for IPv6 addresses.
+# sends empty replies for AAAA queries for IPv6 addresses.
 # This forces clients to switch to using IPv4 addresses.
 push "dhcp-option DNS 10.8.0.1"
 
-# Blackhole IPv6
+# Blackhole IPv6 traffic because GCE does not support IPv6.
+# This is achieved by making OpenVPN server have a fake IPv6 address
+# (otherwise OpenVPN server will not push IPv6 information to
+# client) and pushing a route to the client to blackhole IPv6 traffic
+# client-side.
+server-ipv6 2001:db8:123::/64
+# OpenVPN 2.3 doesn't work well with IPv6. Push a route to client
+# to blackhole IPv6 traffic on the client.
 push "route-ipv6 2000::/3"
 
 # Enabling floating mode to work around the issue where


### PR DESCRIPTION
This fixes two issues:
1. Custom built dnsmasq did not overwrite the original dnsmasq.
   As a result, AAAA DNS lookups returned non-empty results letting
   clients resolve DNS names to IPv6 addresses.
2. OpenVPN server wasn't assigned an IPv6 address and thus didn't
   correctly push IPv6 settings to clients.

Fixes #28
