### PR TITLE
Fix bug with muting with vuln notifications for multiple packages

### DIFF
--- a/nogotofail/clients/android/src/net/nogotofail/MuteNotificationsReceiver.java
+++ b/nogotofail/clients/android/src/net/nogotofail/MuteNotificationsReceiver.java
@@ -56,7 +56,7 @@ public class MuteNotificationsReceiver extends BroadcastReceiver {
     vulnerabilityType = values[0];
     List<String> packageNames = new ArrayList<String>(values.length - 1);
     for (int i = 1; i < values.length; i++) {
-      packageNames.add(values[1]);
+      packageNames.add(values[i]);
     }
     NotificationsPreferenceFragment.muteNotificationForPackages(
         context, vulnerabilityType, packageNames);


### PR DESCRIPTION
Due to a typo, muting such a notification muted it only for the
first package in the list.
