### PR TITLE
Fix a typo in ccs.py

### DIFF
--- a/nogotofail/mitm/connection/handlers/connection/ccs.py
+++ b/nogotofail/mitm/connection/handlers/connection/ccs.py
@@ -120,7 +120,7 @@ class EarlyCCS(LoggingHandler):
             # record. Buffer the response to try and get more data.
             self.buffer = response
             # But don't buffer too much, give up after 16k.
-            if len(self.buffer > 2**14):
+            if len(self.buffer) > 2**14:
                 response = self.buffer
                 self.buffer = ""
                 return self.buffer


### PR DESCRIPTION
This typo leads to a crash because len cannot be invoked on bool.
