### PR TITLE
Use constants for tls protocol values.

### DIFF
--- a/nogotofail/mitm/connection/connection.py
+++ b/nogotofail/mitm/connection/connection.py
@@ -21,6 +21,7 @@ import socket
 import struct
 from nogotofail.mitm.util import tls, ssl2
 from nogotofail.mitm.util import close_quietly
+from nogotofail.mitm.util.tls.types import Extension
 import time
 import uuid
 import errno
@@ -227,7 +228,7 @@ class BaseConnection(object):
         5. At this point the SSL MiTM is set up and we switch back to bridging mode
         """
         self.client_hello = client_hello
-        server_name = client_hello.extensions.get("server_name")
+        server_name = client_hello.extensions.get(Extension.TYPES.SERVER_NAME)
         if server_name:
             server_name = server_name.data
             self.hostname = server_name
@@ -365,7 +366,7 @@ class BaseConnection(object):
         """
         # Check for a server name and set our hostname
         if not self.hostname:
-            server_name = client_hello.extensions.get("server_name")
+            server_name = client_hello.extensions.get(Extension.TYPES.SERVER_NAME)
             if server_name:
                 server_name = server_name.data
                 self.hostname = server_name

--- a/nogotofail/mitm/util/__init__.py
+++ b/nogotofail/mitm/util/__init__.py
@@ -16,6 +16,7 @@ limitations under the License.
 import routing
 from ca import CertificateAuthority
 from ip import get_interface_addresses
+from constant import Constants
 from socket import close_quietly
 import vuln
 import http

--- a/nogotofail/mitm/util/constant.py
+++ b/nogotofail/mitm/util/constant.py
@@ -1,0 +1,49 @@
+r'''
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+class Constants(object):
+    class _Meta(type):
+        def __getattr__(cls, attr):
+            if attr in cls.__dict__:
+                return cls.__dict__[attr]
+            if attr in cls._constants:
+                return cls._constants[attr]
+            else:
+                raise AttributeError(attr)
+
+        def __setattr__(cls, attr, value):
+            raise AttributeError("Cannot set constants")
+
+        def __dir__(cls):
+            return cls._constants.keys()
+
+    __metaclass__ = _Meta
+
+    class Constant():
+        def __init__(self, name, value):
+            self.name = name
+            self.value = value
+        def __getattr__(self, attr):
+            return getattr(self.value, attr)
+        def __str__(self):
+            return self.name
+        def __repr__(self):
+            return self.__str__()
+
+    @staticmethod
+    def constants(items):
+        return {k: Constants.Constant(k, v) for k,v in items.items()}
+

--- a/nogotofail/mitm/util/tls/types/alert.py
+++ b/nogotofail/mitm/util/tls/types/alert.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 import struct
+from nogotofail.mitm.util import Constants
 
 level_names = {
     1: "warning",
@@ -50,8 +51,14 @@ description_names = {
 }
 
 class Alert(object):
-    LEVEL_FATAL = 2
-    LEVEL_WARNING = 1
+
+    class DESCRIPTION(Constants):
+        _constants = Constants.constants(
+                {name.upper(): value for value, name in description_names.items()})
+
+    class LEVEL(Constants):
+        _constants = Constants.constants(
+                {name.upper(): value for value, name in level_names.items()})
 
     def __init__(self, level, description):
         self.level = level
@@ -71,4 +78,3 @@ class Alert(object):
         return ("TLS alert: %s (%d) %s (%d)"
             % (level_names.get(self.level), self.level,
                description_names.get(self.description), self.description))
-

--- a/nogotofail/mitm/util/tls/types/extension.py
+++ b/nogotofail/mitm/util/tls/types/extension.py
@@ -13,8 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
+import string
 import struct
 import base64
+from nogotofail.mitm.util import Constants
 from nogotofail.mitm.util.tls.types import parse
 
 # Map of extension_types to strings
@@ -50,6 +52,11 @@ name_map = {
 
 
 class Extension(object):
+
+    class TYPES(Constants):
+        _constants = Constants.constants(
+                {name.translate(string.maketrans(" ","_"),"()").upper() : value
+                    for value, name in name_map.items()})
 
     def __init__(self, extension_type, extension_data):
         self.type = extension_type

--- a/nogotofail/mitm/util/tls/types/handshake.py
+++ b/nogotofail/mitm/util/tls/types/handshake.py
@@ -122,7 +122,7 @@ class ClientHello(object):
         self.ciphers = ciphers
         self.compression_methods = compression_methods
         self.extension_list = extensions
-        self.extensions = {ext.name: ext for ext in extensions}
+        self.extensions = {ext.type: ext for ext in extensions}
 
     def __str__(self):
         extensions = "\n".join(


### PR DESCRIPTION
Instead of hardcoding the values use constants like Alert.LEVEL.FATAL or
Extension.TYPES.SERVER_NAME.

This doesn't create constants for all TLS constants, there are still
more to be done.
