### PR TITLE
Whitelist handshake_failure alert for early CCS

### DIFF
--- a/nogotofail/mitm/connection/handlers/connection/ccs.py
+++ b/nogotofail/mitm/connection/handlers/connection/ccs.py
@@ -61,12 +61,14 @@ class EarlyCCS(LoggingHandler):
                 # so we accept that as well. Morever, if the client doesn't like the TLS
                 # protocol version chosen by the server (regardless of whether early
                 # CCS is injected), the client will send a fatal alert
-                # protocol_version (70).
+                # protocol_version (70) or handshake_failure (40).
                 if not (
                     isinstance(message, tls.types.Alert) and
                        ((message.description == Alert.DESCRIPTION.UNEXPECTED_MESSAGE and
                            message.level == Alert.LEVEL.FATAL) or
                        (message.description == Alert.DESCRIPTION.PROTOCOL_VERSION and
+                           message.level == Alert.LEVEL.FATAL) or
+                       (message.description == Alert.DESCRIPTION.HANDSHAKE_FAilURE and
                            message.level == Alert.LEVEL.FATAL) or
                        message.description == Alert.DESCRIPTION.CLOSE_NOTIFY)):
                     self.log(


### PR DESCRIPTION
Some clients reply with handshake_failure rather than protocol_version when the server chooses a protocol version they don't like.