### PR TITLE
Make blame queries nonblocking.

### DIFF
--- a/nogotofail/mitm/__init__.py
+++ b/nogotofail/mitm/__init__.py
@@ -13,4 +13,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-__all__ = ["connection", "blame", "util", "event"]
+__all__ = ["connection", "blame", "util", "event", "looper"]

--- a/nogotofail/mitm/blame/app_blame.py
+++ b/nogotofail/mitm/blame/app_blame.py
@@ -19,160 +19,217 @@ import socket
 import select
 import sys
 import ssl
-import threading
 import time
 import urllib
 
 from nogotofail.mitm.connection import handlers
+from nogotofail.mitm.util import close_quietly
+
 Application = namedtuple("Application", ["package", "version"])
 
 
 class Client(object):
-    socket = None
-    info = None
-    last_used = None
-
-    def __init__(self, socket, info, now):
-        self.socket = socket
-        self.info = info
-        self.last_used = now
-
-
-def recv_lines(socket):
-    lines = []
-    file = socket.makefile()
-    while True:
-        line = file.readline().strip()
-        if line == "":
-            break
-        lines.append(line)
-    return lines
-
-
-class Server:
-    """Server for managing connections to the connection blaming app on devices.
-    """
-    port = None
-    clients = None
+    """Class representing a blame client connection.
+    NOTE: You should avoid using this directly for client queries because if the client reconnects
+    a new Client will be made."""
     CLIENT_TIMEOUT = 21600
 
-    def __init__(self, port, cert, default_prob, default_attacks, default_data):
-        self.txid = 0
-        self.kill = False
-        self.port = port
-        self.cert = cert
-        self.default_prob = default_prob
-        self.default_attacks = default_attacks
-        self.default_data = default_data
-        self.clients = {}
-        self.listening_thread = threading.Thread(target=self.run)
-        self.listening_thread.daemon = True
+    class Callback(object):
+        def __init__(self, fn, timeout, now=None):
+            self.fn = fn
+            self.timeout = timeout
+            self.start = now or time.time()
+
+    def __init__(self, socket, server, now=None):
+        self.socket = socket
+        self.server = server
+        self.info = None
+        self.last_used = now or time.time()
+        self._select_fn = self._handshake_select_fn
+        self.queries = {}
+        self._txid = 0
+        self._buffer = ""
+        self.address = self.socket.getpeername()[0]
         self.logger = logging.getLogger("nogotofail.mitm")
-        self.server_socket = None
+        self._handshake_completed = False
 
-    def start(self):
-        self.listening_thread.start()
+    @property
+    def available(self):
+        """Returns if the client is currently available."""
+        return self._handshake_completed
 
-    def run(self):
+    @property
+    def next_txid(self):
+        """Returns the next unused transaction id for a blame request."""
+        id = self._txid
+        self._txid += 1
+        return id
+
+    def on_select(self):
+        """Should be called when select has returned self.socket as ready for reading."""
+        self.last_used = time.time()
+        return self._select_fn()
+
+    def check_timeouts(self):
+        """Returns if the connection or any of its callbacks have timed out."""
+        now = time.time
+        if now - self.last_used > self.CLIENT_TIMEOUT:
+            return False
+        for callback in self.queries.values():
+            if now >= callback.start + callback.timeout and callback.timeout != 0:
+                return False
+        return True
+
+    def close(self):
+        """Close the connection to the client. This also notifies all pending queries that their
+        request has failed."""
+        close_quietly(self.socket)
+        for callback in self.queries.values():
+            callback.fn(False)
+
+    def get_applications_async(
+            self, client_port, server_addr, server_port, callback, timeout=10):
+        """See Server.get_applications_async"""
+
+        self.last_used = time.time()
+        txid = self.next_txid
+
+        family = socket.AF_INET6 if ":" in server_addr else socket.AF_INET
+        message = (
+            unicode(
+                "%d tcp_client_id %s %s %s\n" %
+                (txid, client_port,
+                 socket.inet_pton(family, server_addr).encode("hex"),
+                 server_port)))
         try:
-            self.listen()
-        except Exception as e:
-            self.logger.exception("Uncaught exception in Listening thread!")
-            self.logger.critical("EXITING")
-            sys.exit()
+            self.socket.sendall(message)
+        except socket.error as e:
+            self.logger.info(
+                "Blame: Error sending vuln_notify to %s: %s." % (self.address, e))
+            return False
 
-    def listen(self):
-        self.server_socket = socket.socket()
-        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.server_socket.bind(("", self.port))
-        self.server_socket.listen(5)
-        self.server_socket.settimeout(2)
-        if self.cert:
-            self.server_socket = (
-                ssl.wrap_socket(
-                    self.server_socket, certfile=self.cert,
-                    server_side=True))
-        while not self.kill:
+        self.queries[txid] = Client.Callback(
+                self._generate_on_get_applications_fn(callback), timeout)
+        return True
+
+    def vuln_notify_async(self, server_addr, server_port, id,
+            type, applications, callback, timeout=10):
+        """See Server.vuln_notify_async."""
+
+        self.last_used = time.time()
+        txid = self.next_txid
+
+        message = unicode("%d vuln_notify %s %s %s %d %s\n" %
+            (txid, id, type, server_addr, server_port,
+             ", ".join(
+                 ["%s %s" % (urllib.quote(app.package), app.version) for app in applications])))
+        try:
+            self.socket.sendall(message)
+        except socket.error as e:
+            self.logger.info("AppBlame notify error for %s, %s." % (self.address, e))
+            return False
+
+        self.queries[txid] = Client.Callback(
+                self._generate_on_vuln_notify_fn(callback), timeout)
+        return True
+
+    def _generate_on_vuln_notify_fn(self, callback):
+        def on_vuln_notify(success, data=None):
+            if not success:
+                callback(False)
+                self.server.remove_client(self.address)
+                return
+            callback(True, data == "OK")
+        return on_vuln_notify
+
+    def _generate_on_get_applications_fn(self, callback):
+        def on_get_applications(success, data=None):
+            if not success:
+                callback(False)
+                self.server.remove_client(self.address)
+                return
+
+            platform_info = self.info.get(
+                "Platform-Info", "Unknown")
+            apps = data.split(",")
             try:
-                # Check our old sockets and cleanup if needed
-                for client in self.clients.keys():
-                    self.client_available(client)
+                callback(True, platform_info,
+                        [Application(*map(urllib.unquote, app.strip().split(" ", 1)))
+                            for app in apps])
+            except (ValueError, TypeError):
+                callback(False)
+        return on_get_applications
 
-                (client_socket, client_address) = self.server_socket.accept()
-                client_socket.settimeout(2)
-                client_addr, client_port = client_address
-                client_info = None
-
-                # handshake
-                try:
-                    client_info = self._handshake(client_socket)
-                except (ValueError, KeyError, IndexError):
-                    try:
-                        client_socket.sendall("400 Error parsing message\n\n")
-                    except socket.error:
-                        pass
-                    client_socket.close()
-                    self.logger.warning(
-                        "AppBlame bad handshake from %s" % client_addr)
-                    continue
-                except socket.timeout:
-                    client_socket.close()
-                    self.logger.info(
-                        "AppBlame handshake timeout from %s" % client_addr)
-                    continue
-
-                old_client = self.clients.get(client_addr, None)
-                self.clients[client_addr] = Client(
-                    client_socket, client_info, time.time())
-                if old_client:
-                    old_client.socket.close()
-                self.logger.info("AppBlame new client from %s" % client_addr)
-            except socket.timeout:
-                pass
+    def _handshake_select_fn(self):
+        """Handle client data during the handshake."""
+        try:
+            data = self.socket.recv(8192)
+        except socket.error:
+            self.logger.info("Blame: Erorr reading from client %s.", self.address)
+            return False
+        if not data:
+            self.logger.info("Blame: Client %s closed connection.", self.address)
+            return False
+        data = self._buffer + data
+        lines = data.split("\n")
+        # Check if there is still more data to be read.
+        # Some clients send \r\n line endings and some \n, so strip extra
+        # whitespace.
+        if lines[-1].strip() != "":
+            self._buffer = data
+            return
+        data = data.replace("\r", "")
+        lines = data[:data.index("\n\n")].split("\n")
+        try:
+            self._parse_headers(lines)
+            self._send_headers()
+        except (ValueError, KeyError, IndexError, socket.error) as e:
+            try:
+                self.socket.sendall("400 Error parsing message\n\n")
             except socket.error:
-                self.logger.exception("AppBlame socket error")
-        self.server_socket.close()
+                pass
+            self.logger.info("Blame: Bad handshake from %s: %s" % (self.address, e))
+            return False
+        # TODO: Handle any extra data after the handshake, there shouldn't be
+        # any in the current version of the protocol.
+        # Done!
+        self.logger.info("Blame: New client from %s", self.address)
+        self._select_fn = self._response_select_fn
+        self._handshake_completed = True
+        return True
 
-    def _handshake(self, client_socket):
-        lines = recv_lines(client_socket)
-        name, version = lines[0].split("/", 1)
-        if name != "nogotofail_ctl":
-            raise ValueError("Unexpected app type")
-        # Parse out the headers
-        raw_headers = [line.split(":", 1) for line in lines[1:]]
-        headers = {entry.strip(): header.strip()
-                   for entry, header in raw_headers}
-
-        client_info = self._parse_headers(headers)
-
+    def _send_headers(self):
         # Send the OK
-        client_socket.sendall("0 OK\n")
+        self.socket.sendall("0 OK\n")
         # Send the configs
-        prob = client_info.get("Attack-Probability", self.default_prob)
-        client_socket.sendall("Attack-Probability: %f\n" % prob)
-        attacks = client_info.get("Attacks", self.default_attacks)
+        prob = self.info.get("Attack-Probability", self.server.default_prob)
+        self.socket.sendall("Attack-Probability: %f\n" % prob)
+        attacks = self.info.get("Attacks", self.server.default_attacks)
         attacks_str = ",".join([attack.name for attack in attacks])
-        client_socket.sendall("Attacks: %s\n" % attacks_str)
+        self.socket.sendall("Attacks: %s\n" % attacks_str)
         supported_str = ",".join([
             attack
             for attack in
             handlers.connection.handlers.map])
-        client_socket.sendall("Supported-Attacks: %s\n" % supported_str)
-        data = client_info.get("Data-Attacks", self.default_data)
+        self.socket.sendall("Supported-Attacks: %s\n" % supported_str)
+        data = self.info.get("Data-Attacks", self.server.default_data)
         data_str = ",".join([attack.name for attack in data])
-        client_socket.sendall("Data-Attacks: %s\n" % data_str)
+        self.socket.sendall("Data-Attacks: %s\n" % data_str)
         supported_data = ",".join([
             attack
             for attack in handlers.data.handlers.map])
-        client_socket.sendall("Supported-Data-Attacks: %s\n" % supported_data)
+        self.socket.sendall("Supported-Data-Attacks: %s\n" % supported_data)
+        self.socket.sendall("\n")
 
-        client_socket.sendall("\n")
-        return client_info
+    def _parse_headers(self, lines):
+        raw_headers = [line.split(":", 1) for line in lines[1:]]
+        headers = {entry.strip(): header.strip()
+                   for entry, header in raw_headers}
 
-    def _parse_headers(self, headers):
         client_info = {}
-        # Platform-Info is required
+        # Platform-Info is required, fail if not present
         client_info["Platform-Info"] = headers["Platform-Info"]
+        # Everything else is optional
         if "Installation-ID" in headers:
             client_info["Installation-ID"] = headers["Installation-ID"]
 
@@ -186,154 +243,199 @@ class Server:
             attacks = headers["Attacks"].split(",")
             attacks = map(str.strip, attacks)
             client_info["Attacks"] = [
-                handlers.connection.handlers.map[attack] for attack in attacks
-                if attack in handlers.connection.handlers.map]
+                    handlers.connection.handlers.map[attack] for attack in attacks
+                    if attack in handlers.connection.handlers.map]
 
         if "Data-Attacks" in headers:
             attacks = headers["Data-Attacks"].split(",")
             attacks = map(str.strip, attacks)
             client_info["Data-Attacks"] = [handlers.data.handlers.map[attack]
-                                           for attack in attacks
-                                           if attack in
-                                           handlers.data.handlers.map]
+                    for attack in attacks
+                    if attack in
+                    handlers.data.handlers.map]
 
         # Store the raw headers as well in case a handler needs something the
         # client sent in an additional header
         client_info["headers"] = headers
 
-        return client_info
+        self.info = client_info
+
+    def _response_select_fn(self):
+        try:
+            data = self.socket.recv(8192)
+        except socket.error:
+            self.logger.info("Blame: Erorr reading from client %s.", self.address)
+            return False
+
+        if not data:
+            self.logger.info("Blame: Client %s closed connection", self.address)
+            return False
+        data = self._buffer + data
+        while "\n" in data:
+            line, rest = data.split("\n", 1)
+            self._handle_client_line(line)
+            data = rest
+        self._buffer = data
+        return True
+
+    def _handle_client_line(self, line):
+        # A response is either "id <response>\n" or "id\n" if the command failed.
+        words = line.strip().split(" ")
+        txid = int(words[0])
+        data = " ".join(words[1:])
+        callback = self.queries.get(txid)
+        if callback:
+            del self.queries[txid]
+            callback.fn(True, data)
+        else:
+            self.logger.debug("Blame: Response for unknown txid %d from %s", txid, self.address)
+
+
+class Server:
+    """Server for managing connections to the connection blaming app on devices."""
+    port = None
+    clients = None
+
+    def __init__(self, port, cert, default_prob, default_attacks, default_data):
+        self.txid = 0
+        self.kill = False
+        self.port = port
+        self.cert = cert
+        self.default_prob = default_prob
+        self.default_attacks = default_attacks
+        self.default_data = default_data
+        self.clients = {}
+        self.fd_map = {}
+        self.logger = logging.getLogger("nogotofail.mitm")
+        self.server_socket = None
+
+    def start_listening(self):
+        self.server_socket = socket.socket()
+        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server_socket.bind(("", self.port))
+        self.server_socket.listen(5)
+        self.server_socket.settimeout(2)
+        if self.cert:
+            self.server_socket = (
+                ssl.wrap_socket(
+                    self.server_socket, certfile=self.cert,
+                    server_side=True))
+
+    def _on_server_socket_select(self):
+        try:
+            (client_socket, client_address) = self.server_socket.accept()
+        except socket.error:
+            # In a wrapped SSL socket accept() can raise exceptions, if we get
+            # one the client connection is broken so do nothing.
+            return
+        client_addr, client_port = client_address
+        self.logger.debug("Blame: Connection from %s:%d", client_addr, client_port)
+
+        old_client = self.clients.get(client_addr, None)
+        if old_client:
+            self.remove_client(client_address)
+        self.fd_map[client_socket] = client_addr
+        self.clients[client_addr] = Client(client_socket, self)
+
+    def _on_socket_select(self, sock):
+        if sock is self.server_socket:
+            self._on_server_socket_select()
+            return
+        client_addr = self.fd_map[sock]
+        client = self.clients[client_addr]
+        if not client.on_select():
+            self.remove_client(client_addr)
 
     def client_available(self, client_addr):
         """Returns if the app blame client is running on client_addr.
 
         This is best effort only, it may return True for lost clients.
         """
-        client = self.clients.get(client_addr, None)
-        if not client:
-            return False
-        now = time.time()
-        if now - client.last_used > Server.CLIENT_TIMEOUT:
-            self.logger.info("AppBlame pruning client %s", client_addr)
-            del self.clients[client_addr]
-            client.socket.close()
-            return False
+        return client_addr in self.clients and self.clients[client_addr].available
 
-        return True
-
-    def get_applications(
-        self, client_addr, client_port, server_addr, server_port):
-        """Get the list of applications that owns the (client_addr, client_port, server_addr, server_port) connection on the device.
-
-        Returns a tuple containing the platform info string and a list of
-        Application or None if the
-        client is available.
-        """
-        if not self.client_available(client_addr):
-            return None
-
-        client = self.clients[client_addr]
-        client_socket = client.socket
-        client.last_used = time.time()
-
-        txid = self.txid
-        self.txid += 1
-
-        family = socket.AF_INET6 if ":" in server_addr else socket.AF_INET
-
-        message = (
-            unicode(
-                "%d tcp_client_id %s %s %s\n" %
-                (txid, client_port,
-                 socket.inet_pton(family, server_addr).encode("hex"),
-                 server_port)))
-        try:
-            client_socket.sendall(message)
-            response = client_socket.recv(8192)
-            if response == "":
-                raise ValueError("Socket closed")
-            response = unicode(response).strip()
-        except (socket.error, ValueError) as e:
-            self.logger.info(
-                "AppBlame error for %s, %s. Removing." % (client_addr, e))
-            del self.clients[client_addr]
-            client_socket.close()
-            return None
-
-        try:
-            inid, apps = response.split(" ", 1)
-        except ValueError:
-            return None
-        if int(inid) != txid:
-            self.logger.error("Blame response for wrong txid, expected %s got %s" % (txid, inid))
-            return None
-        platform_info = self.clients[client_addr].info.get(
-            "Platform-Info", "Unknown")
-        apps = apps.split(",")
-        try:
-            return platform_info, [Application(
-                *map(urllib.unquote, app.strip().split(" ", 1)))
-                                   for app in apps]
-        except (ValueError, TypeError):
-            return None
-
-    def vuln_notify(
-        self, client_addr, server_addr, server_port, id, type,
-        applications):
-        """Send a notification to client_addr of a vulnerability in applications.
+    def get_applications_async(
+            self, client_addr, client_port, server_addr, server_port, callback, timeout=10):
+        """Fetch the application information for a given connection tuple calling a callback when
+        the response is received.
+        Returns if the request was sent to the client.
+        NOTE: If False is returned the callback will never be called.
 
         Arguments:
-            client_addr: Client to notify
-            server_addr: remote destination of the vulnerable connection
-            server_port: remote port of the vulnerable connection
-            id: An opaque blob to identify the connection later on
-            type: Type of vuln. See nogotofail.mitm.util.vuln.*
-            applications: List of Applications to blame
+        client_addr -- the client ip address to query
+        client_port -- the source port on the client
+        server_addr -- the destination ip address as seen by the client
+        server_port -- the destination port as seen by the client
+        callback -- function to call when data is ready, should be of the form
+                    def fn(success, platform_info=None, applications=None)
+        timeout --  timeout for the request"""
+        if not self.client_available(client_addr):
+            return False
+        if not self.clients[client_addr].get_applications_async(client_port,
+                server_addr, server_port, callback, timeout):
+            self.remove_client(client_addr)
+            return False
+        return True
 
+
+    def vuln_notify_async(self, client_addr, server_addr, server_port, id,
+            type, applications, callback, timeout=10):
+        """Send a notification to client_addr of a vulnerability in applications.
         Returns if the notification was sent successfully
+
+        Arguments:
+            client_addr -- Client to notify
+            server_addr -- remote destination of the vulnerable connection
+            server_port -- remote port of the vulnerable connection
+            id -- An opaque blob to identify the connection later on
+            type -- Type of vuln. See nogotofail.mitm.util.vuln.*
+            applications -- List of Applications to blame
+            callback -- Function to call when a response is received. Should be of the form:
+                def callback(success, result=False)
+                    success -- If the client responded to the notification
+                    result -- If the client showed the vulnerability
         """
 
         if not self.client_available(client_addr):
             return False
+        result = self.clients[client_addr].vuln_notify_async(server_addr, server_port,
+                id, type, applications, callback, timeout)
+        if not result:
+            self.remove_client(client_addr)
+        return result
 
+    def remove_client(self, client_addr):
+        """Remove and close a blame client."""
+        if client_addr not in self.clients:
+            return
         client = self.clients[client_addr]
-        client_socket = client.socket
-        client.last_used = time.time()
+        del self.clients[client_addr]
+        del self.fd_map[client.socket]
+        client.close()
 
-        txid = self.txid
-        self.txid += 1
-        message = (
-            unicode("%d vuln_notify %s %s %s %d %s\n") %
-            (txid, id, type, server_addr, server_port,
-             ", ".join(
-                 [
-                     "%s %s" % (urllib.quote(app.package), app.version)
-                     for app in applications])))
-        try:
-            client_socket.sendall(message)
-            response = client_socket.recv(8192)
-            if response == "":
-                raise ValueError("Socket closed")
-            response = unicode(response).strip()
-        except (socket.error, ValueError) as e:
-            self.logger.info(
-                "AppBlame notify error for %s, %s. Removing." %
-                (client_addr, e))
-            del self.clients[client_addr]
-            client_socket.close()
-            return False
-        id, message = response.split(" ", 2)
-        if int(id) != txid:
-            self.logger.error("Blame response for wrong txid, expected %s got %s" % (txid, id))
-            return False
+    def check_timeouts(self):
+        """Check the timeouts on all clients and remove those that have timed out."""
+        for client_addr in self.clients.keys():
+            if not self.clients[client_addr].check_timeouts():
+                self.logger.info("Blame: Client %s timed out", client_addr)
+                self.remove_client(client_addr)
 
-        return message == "OK"
+    @property
+    def select_fds(self):
+        """Returns the tuple of r,w,x fds to be sent to select."""
+        return (set([client.socket for client in self.clients.values()] + [self.server_socket])
+                , set(), set())
+
+    def on_select(self, r, w, x):
+        """Called whith the results of select.select. Note that all r,w,x is a subset of the values
+        provided by select_fds."""
+        for fd in set(r + w + x):
+            self._on_socket_select(fd)
 
     def shutdown(self):
-        self.kill = True
+        """Shutdown the Blame server. The server should not be used after this point."""
         self.server_socket.close()
-        self.listening_thread.join(5)
         for client in self.clients.values():
             try:
-                client.socket.close()
+                client.close()
             except:
                 pass

--- a/nogotofail/mitm/connection/server.py
+++ b/nogotofail/mitm/connection/server.py
@@ -17,7 +17,6 @@ from nogotofail.mitm.connection import RedirectConnection
 from nogotofail.mitm.connection.handlers.selector import default_connection_selector, default_ssl_connection_selector, default_data_selector
 from nogotofail.mitm import util
 
-import threading
 import socket
 import select
 import os
@@ -36,117 +35,48 @@ class Server:
                  block_non_clients=False, ipv6=False):
         self.kill = False
         self.port = port
-        self.kill_fd, self.control_fd = self.setup_control_pipe()
-        self.read_fds = set([self.kill_fd])
+        self.read_fds = set()
         self.write_fds = set()
         self.ex_fds = set()
+        self._local_server_sockets = []
         self.fds = {}
         self.connections = {}
         self.connection_class = connection_class
         self.handler_selector = handler_selector
         self.ssl_handler_selector = ssl_handler_selector
         self.data_handler_selector = data_handler_selector
-        self.serving_thread = threading.Thread(target=self.run)
-        self.serving_thread.daemon = True
         self.app_blame = app_blame
         self.logger = logging.getLogger("nogotofail.mitm")
         self.block_non_clients = block_non_clients
         self.ipv6 = ipv6
+        self.last_reap = time.time()
 
-    def start(self):
-        self.serving_thread.start()
-
-    def run(self):
-        try:
-            self.serve()
-        except Exception as e:
-            self.logger.exception("Uncaught exception in serving thread!")
-            self.logger.critical("EXITING")
-            sys.exit()
-
-    def _create_server_sockets(self):
-        sockets = []
-        for family in [socket.AF_INET, socket.AF_INET6]:
-            if family == socket.AF_INET6 and not self.ipv6:
-                break
-            local_server_socket = socket.socket(family=family)
-            if family == socket.AF_INET6:
-                # Force into ipv6 only mode. We will bind a v4 and v6 socket.
-                # This makes compat a little easier
-                local_server_socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
-            local_server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            self.connection_class.setup_server_socket(local_server_socket)
-            local_server_socket.bind(("", self.port))
-            local_server_socket.listen(5)
-            sockets.append(local_server_socket)
-        return sockets
-
-    def serve(self):
-        last_reap = time.time()
-
-        # set up the listening sockets
-        local_server_sockets = self._create_server_sockets()
-        for sock in local_server_sockets:
+    def start_listening(self):
+        self._local_server_sockets = self._create_server_sockets()
+        for sock in self._local_server_sockets:
             self.read_fds.add(sock)
 
-        while not self.kill:
-            r, w, x = select.select(self.read_fds,
-                    self.write_fds,
-                    self.ex_fds,
-                    10)
-            for fd in r + w + x:
-                if fd == self.kill_fd:
-                    return
-                if fd in local_server_sockets:
-                    client_socket, client_address = None, (None, None)
-                    try:
-                        (client_socket, client_address) = (
-                            fd.accept())
-                        self.setup_connection(client_socket)
-                    except socket.error as e:
-                        self.logger.error(
-                            "Socket error in connection startup from %s" % client_address[0])
-                        self.logger.exception(e)
-                        util.close_quietly(client_socket)
+    @property
+    def select_fds(self):
+        return self.read_fds, self.write_fds, self.ex_fds
+
+
+    def on_select(self, r, w, x):
+        for fd in r + w + x:
+            if fd in self._local_server_sockets:
+                self._on_server_socket_select(fd)
+            else:
+                self._on_connection_socket_select(fd)
+
+        # If nothing is happening and we haven't reaped in a while reap
+        now = time.time()
+        if (len(r) == 0 and now - self.last_reap > 600) or now - self.last_reap > 3600:
+            self.last_reap = now
+            for conn in set(self.connections.values()):
+                if not isinstance(conn, self.connection_class):
                     continue
-                try:
-                    conn = self.connections[fd]
-                except KeyError:
-                    # fd could have already been removed if the other end of the socket closed
-                    # and was handled before fd. fd has already been handled so
-                    # move along
-                    continue
-                try:
-                    cont = conn.bridge(fd)
-                    if not cont:
-                        self.remove(conn)
-                except Exception as e:
-                    self.logger.exception(e)
+                if now - conn.last_used > 3600:
                     self.remove(conn)
-
-            # If nothing is happening and we haven't reaped in a while reap
-            now = time.time()
-            if (len(r) == 0 and now - last_reap > 600) or now - last_reap > 3600:
-                for conn in set(self.connections.values()):
-                    if not isinstance(conn, self.connection_class):
-                        continue
-                    if now - conn.last_used > 3600:
-                        self.remove(conn)
-
-    def _remove_fds(self, connection):
-        if connection in self.fds:
-            r, w, x = self.fds[connection]
-            for fd in r:
-                self.read_fds.remove(fd)
-                self.connections.pop(fd)
-            for fd in w:
-                self.write_fds.remove(fd)
-                self.connections.pop(fd)
-            for fd in x:
-                self.ex_fds.remove(fd)
-                self.connections.pop(fd)
-
-            del self.fds[connection]
 
     def remove(self, connection):
         connection.close(handler_initiated=False)
@@ -170,16 +100,8 @@ class Server:
         if connection.start():
             self.set_select_fds(connection)
 
-    def setup_control_pipe(self):
-        killer, controller = os.pipe()
-        return killer, controller
-
     def shutdown(self):
-        self.kill = True
-        os.write(self.control_fd, "Die!")
-        self.serving_thread.join(5)
         for sock in self.read_fds | self.write_fds | self.ex_fds:
-            if sock != self.kill_fd:
                 util.close_quietly(sock)
 
     def set_select_fds(self, connection):
@@ -197,3 +119,63 @@ class Server:
         self.ex_fds.update(x)
         for fd in set(r + w + x):
             self.connections[fd] = connection
+
+    def _create_server_sockets(self):
+        sockets = []
+        for family in [socket.AF_INET, socket.AF_INET6]:
+            if family == socket.AF_INET6 and not self.ipv6:
+                break
+            local_server_socket = socket.socket(family=family)
+            if family == socket.AF_INET6:
+                # Force into ipv6 only mode. We will bind a v4 and v6 socket.
+                # This makes compat a little easier
+                local_server_socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+            local_server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.connection_class.setup_server_socket(local_server_socket)
+            local_server_socket.bind(("", self.port))
+            local_server_socket.listen(5)
+            sockets.append(local_server_socket)
+        return sockets
+
+    def _remove_fds(self, connection):
+        if connection in self.fds:
+            r, w, x = self.fds[connection]
+            for fd in r:
+                self.read_fds.remove(fd)
+                self.connections.pop(fd)
+            for fd in w:
+                self.write_fds.remove(fd)
+                self.connections.pop(fd)
+            for fd in x:
+                self.ex_fds.remove(fd)
+                self.connections.pop(fd)
+
+            del self.fds[connection]
+
+    def _on_server_socket_select(self, fd):
+        client_socket, client_address = None, (None, None)
+        try:
+            (client_socket, client_address) = (
+                fd.accept())
+            self.setup_connection(client_socket)
+        except socket.error as e:
+            self.logger.error(
+                "Socket error in connection startup from %s" % client_address[0])
+            self.logger.exception(e)
+            util.close_quietly(client_socket)
+
+    def _on_connection_socket_select(self, fd):
+        try:
+            conn = self.connections[fd]
+        except KeyError:
+            # fd could have already been removed if the other end of the socket closed
+            # and was handled before fd. fd has already been handled so
+            # move along
+            return
+        try:
+            cont = conn.bridge(fd)
+            if not cont:
+                self.remove(conn)
+        except Exception as e:
+            self.logger.exception(e)
+            self.remove(conn)

--- a/nogotofail/mitm/looper.py
+++ b/nogotofail/mitm/looper.py
@@ -1,0 +1,48 @@
+r'''
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+import select
+
+class MitmLoop(object):
+    """Handles the main loop for running nogotofail.mitm."""
+    def __init__(self, blame_server, connection_server):
+        self._servers = [blame_server, connection_server]
+    def run(self, only_once=False, timeout=5):
+        """Run the MitmLoop.
+        This calls select on all active sockets and dispatches the resulting sockets to the
+        connection and blame servers.
+
+        Keyword arguments:
+        only_once -- run the select loop only once instead of forever (default False)
+        timeout -- the timeout for select in seconds (default 5)
+        """
+        servers = self._servers
+        while True:
+            # Build the map of fds we are actively selecting over. This changes
+            # from pass to pass and connections come and go and change state.
+            fds = {server: set([sock for fds in server.select_fds for sock in fds])
+                    for server in servers}
+            r, w, x = [set().union(*l) for l in zip(*[server.select_fds for server in servers])]
+            r, w, x = select.select(r, w, x, timeout)
+            # Call on_select with all the fds we found from each server.
+            for server in servers:
+                filter_func = lambda fd: fd in fds[server]
+                server.on_select(filter(filter_func, r),
+                        filter(filter_func, w),
+                        filter(filter_func, x))
+
+            if only_once:
+                return
+


### PR DESCRIPTION
Previously blame queries were done blocking the connection thread, this
caused a big hit in performance when blaming a lot of connections. Now
get_applications and vuln_notify are async and take callbacks. Currently
connections still block until the blame info has come back(but not the
thread).

Also remove the threading in server/blame server. Since everything is
select based move to a single select loop over all the sockets we care
about (nogotofail.mitm.looper.Looper).

Because of the timing of blaming and handler events some events may be
called before the blame result comes back. Currently we block actually
using the connection until the blame result comes back so on_establish
and everything after that has the blame info. on_select no longer does
however.

Currently the blame client is only queried at the start of a connection,
so if the client shows up after the connection starts it wont get
blamed. Will fix this regression in a follow up commit.

Fixes #40