### PR TITLE
Always use nonblocking socket operations.

### DIFF
--- a/nogotofail/mitm/connection/handlers/data/http.py
+++ b/nogotofail/mitm/connection/handlers/data/http.py
@@ -116,7 +116,7 @@ class _ResponseReplacement(DataHandler):
         return request
 
 
-@handler(handlers)
+@handler(handlers, default=False)
 class AndroidWebviewJsRce(_ResponseReplacement):
 
     name = "androidwebviewjsrce"
@@ -183,7 +183,7 @@ class AndroidWebviewJsRce(_ResponseReplacement):
         return data
 
 
-@handler(handlers)
+@handler(handlers, default=False)
 class SSLStrip(_ResponseReplacement):
     """Replace https urls with http. Uses the reporting mechanism to
     detect when these URLs are later visited and warns/notifies.


### PR DESCRIPTION
With SSL wrapped sockets select is not a perfect indicator of if there
is application data ready for reading, so keep connection sockets nonblocking at
all times.

This also fixes issues in nogotofail.mitm.connection where socket.sendall could
block because of a full send buffer.

This temporarily disables SSLstrip/Webview JS RCE from loading as
default since they are especially fragile when it comes to short reads
of application data, which happens a lot more now. A fix will be
upcoming.