### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/docs/gce/mitm.conf
+++ b/docs/gce/mitm.conf
@@ -10,7 +10,6 @@
 #attacks=selfsigned invalidhostname
 #data=httpdetection httpauthdetection
 
-all=True
 probability=0.5
 
 serverssl=/etc/nogotofail/mitm_controller_cert_and_key.pem

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -58,11 +58,9 @@ Here is a quick walkthrough of running and testing the MiTM locally.
 
 First, we’ll start the MiTM running as a SOCKS5 proxy.
 
-    $ python -m nogotofail.mitm -v -a --mode socks --port 8080 --serverssl server.crt
+    $ python -m nogotofail.mitm --mode socks --port 8080 --serverssl server.crt
 
 ````
--v - verbose logging, this shows all information about a connection and not just attack successes
--a - Attack all connections, without this the mitm will only attack connections from hosts running a nogotofail client.
 --mode socks - run as a SOCKS5 proxy
 --port 8080 - listen on 8080
 --serverssl servert.crt- The certificate we generated above. This will be used for the client connections.
@@ -234,9 +232,6 @@ root so it can set up the routing rules to intercept traffic.
 nogotofail.mitm has a lot of configuration options, here are some of the
 important ones you’ll want to tweak.
 
-    -a/--all : Attack all connections. By default the mitm will only attack
-    connections from addresses with a client running and let all other connections
-    pass through silently.
     -p/--probability: Set the probability of attack an TLS/SSL connection. See the
     “Why Probability” section for details on probability.
     -A/--Attacks: Set the default connection handlers to run when TLS/SSL is

--- a/nogotofail/__init__.py
+++ b/nogotofail/__init__.py
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
-version_info = (1, 0, 0)
+version_info = (1, 1, 0)
 __version__ = ".".join([str(v) for v in version_info])


### PR DESCRIPTION
Changes since 1.0:

Add serverkeyreplace TLS/SSL attack to test that clients verify that the
server possesses the private key corresponding to the SSL certificate
that was presented to the client.

Data handlers that can modify the connection data are now run
probabilistically with the same probability as set with -p or by the
client. Passive detection handlers will still run on all connections.

Nogotofail clients will now receive vulnerability notifications when
HTTP is detected. To prevent spamming the Android client supports muting
on a per (application, vulnerability) level.

Removed the -a and -v nogotofail.mitm flags and made them default.
The -b and -q flags were added to bridge all connections from
non-clients and limit logging respectively.

Improved connection throughput and make calls to the nogotofail clients
non-blocking.

Improved robustness of earlyCCS TLS/SSL attack.

Added a basic android test app under nogotofail/test/android with a
handful of vulnerabilities.