### PR TITLE
GCE Readme.md - fixed path to mitm.conf and removed reference to server.crt

### DIFF
--- a/docs/gce/readme.md
+++ b/docs/gce/readme.md
@@ -42,10 +42,9 @@ to the GCE instance via OpenVPN.
    by the MiTM by looking at / tailing /var/log/nogotofail/mitm.log.
 
 ### Configuring the GCE instance
-The /opt/nogotofail directory is the home folder for the mitm daemon and is where configuration options reside, including:
-* mitm.conf: Daemon configuration file.
-* server.crt: Self-signed certificate used to secure traffic between the mitm daemon and client.
-* trusted-cert.pem: Certificate used for the invalid hostname attack. This certificate needs to containt the the full certificate chain in pem format. 
+Configuration options for the mitm daemon are:
+* /etc/nogotofail/mitm.conf: Daemon configuration file. See the example configuration file included [mitm.conf](mitm.conf).
+* /opt/nogotofail/trusted-cert.pem: Certificate used for the invalid hostname attack. The file must contain the full certificate chain and the private key. 
 
 The mitm daemon can be started, stopped and restarted using the commands
 


### PR DESCRIPTION
This pr is a correction to some of the text in the recent changes to the docs/gce/readme.md document. Corrections made were:
- Fixed path to the mitm.conf file, and 
- Removed the reference to server.crt
I  added these changes as a new (separate) commit.