### PR TITLE
Fix static usage of BufferState

### DIFF
--- a/nogotofail/mitm/connection/handlers/data/http.py
+++ b/nogotofail/mitm/connection/handlers/data/http.py
@@ -49,10 +49,12 @@ class BufferedHttpHandler(DataHandler):
             self.buffer = ""
             self.remaining = 0
 
-    request_state = BufferState()
-    response_state = BufferState()
 
     MAX_LENGTH = 2**22
+
+    def on_select(self):
+        self.request_state = BufferedHttpHandler.BufferState()
+        self.response_state = BufferedHttpHandler.BufferState()
 
     def on_request(self, request):
         return self._handle_data(request, self.request_state)


### PR DESCRIPTION
The http buffering handler was using a static BufferState causing issues
when multiple connections were happening in parallel.