### PR TITLE
Improve ngtf File handling

### DIFF
--- a/nogotofail/mitm/__main__.py
+++ b/nogotofail/mitm/__main__.py
@@ -33,7 +33,7 @@ from nogotofail.mitm.blame import Server as AppBlameServer
 from nogotofail.mitm.connection import Server, RedirectConnection, SocksConnection, TproxyConnection
 from nogotofail.mitm.connection import handlers
 from nogotofail.mitm.looper import MitmLoop
-from nogotofail.mitm.util import routing
+from nogotofail.mitm.util import routing, extras
 
 LOG_FORMAT = logging.Formatter("%(asctime)-15s [%(levelname)s] %(message)s")
 EVENT_FORMAT = logging.Formatter("%(message)s")
@@ -235,6 +235,9 @@ def parse_args():
     parser.add_argument(
         "--mode", help="Traffic capture mode. Options are " + ", ".join(modes.keys()),
         choices=modes, metavar="MODE", action="store", default=default_mode)
+    parser.add_argument(
+        "-x", "--extrasdir", help="Directory containing extra files required by handlers",
+        default = "./")
     parser.set_defaults(**config)
     return parser.parse_args(argv)
 
@@ -289,6 +292,7 @@ def run():
 
     args = parse_args()
     setup_logging(args)
+    extras.extras_dir = args.extrasdir
 
     selector = build_selector(args.all)
     attack_cls = [handlers.connection.handlers.map[name]

--- a/nogotofail/mitm/connection/connection.py
+++ b/nogotofail/mitm/connection/connection.py
@@ -19,7 +19,7 @@ import logging
 import select
 import socket
 import struct
-from nogotofail.mitm.util import tls, ssl2
+from nogotofail.mitm.util import tls, ssl2, extras
 from nogotofail.mitm.util import close_quietly
 from nogotofail.mitm.util.tls.types import Extension
 import time
@@ -282,7 +282,7 @@ class BaseConnection(object):
             context.use_privatekey_file(handler_cert)
 
         # Required for anonymous/ephemeral DH cipher suites
-        context.load_tmp_dh("./dhparam")
+        context.load_tmp_dh(extras.get_extras_path("./dhparam"))
 
         # Required for anonymous/ephemeral ECDH cipher suites
         # The API is not available in the old version of pyOpenSSL which we

--- a/nogotofail/mitm/connection/connection.py
+++ b/nogotofail/mitm/connection/connection.py
@@ -25,6 +25,7 @@ from nogotofail.mitm.util.tls.types import Extension
 import time
 import uuid
 import errno
+import os
 
 class ConnectionWrapper(object):
     """Wrapper around OpenSSL's Connection object to make recv act like socket.recv()
@@ -282,7 +283,11 @@ class BaseConnection(object):
             context.use_privatekey_file(handler_cert)
 
         # Required for anonymous/ephemeral DH cipher suites
-        context.load_tmp_dh(extras.get_extras_path("./dhparam"))
+        params_path = extras.get_extras_path("./dhparam")
+        if os.path.exists(params_path):
+            context.load_tmp_dh(extras.get_extras_path("./dhparam"))
+        else:
+            self.logger.warning("Required file dhparam not found, anonymous/ephemeral DH cipher suites may not work")
 
         # Required for anonymous/ephemeral ECDH cipher suites
         # The API is not available in the old version of pyOpenSSL which we

--- a/nogotofail/mitm/connection/handlers/connection/invalidhostname.py
+++ b/nogotofail/mitm/connection/handlers/connection/invalidhostname.py
@@ -26,8 +26,11 @@ class InvalidHostnameMITM(SelfSignedMITM):
     description = (
         "Attempts to MiTM using a valid certificate for another domain."
         " NOTE: requires ./trusted-cert.pem have a valid cert and private key")
-    certificate = "./trusted-cert.pem"
+    certificate_file = "./trusted-cert.pem"
     vuln = util.vuln.VULN_TLS_INVALID_HOSTNAME
 
+    @property
+    def certificate(self):
+        return util.extras.get_extras_path(self.certificate_file)
     def on_certificate(self, server_cert):
         return self.certificate

--- a/nogotofail/mitm/connection/handlers/data/http.py
+++ b/nogotofail/mitm/connection/handlers/data/http.py
@@ -402,8 +402,8 @@ class ImageReplacement(_ResponseReplacement):
 
     name = "imagereplace"
     description = (
-        "Replace responses with Content-Type of image/* with ./replace.png")
-    file = "./replace.png"
+        "Replace responses with Content-Type of image/* with replace.png")
+    file = "replace.png"
     data = None
 
     def filter(self, response):
@@ -416,7 +416,7 @@ class ImageReplacement(_ResponseReplacement):
         resp = util.http.parse_response(response)
         headers = dict(resp.getheaders())
         if not ImageReplacement.data:
-            with open(self.file) as f:
+            with open(util.extras.get_extras_path(self.file)) as f:
                 ImageReplacement.data = f.read()
         old_length = int(headers.get("content-length", 0))
         length = len(self.data)

--- a/nogotofail/mitm/util/extras.py
+++ b/nogotofail/mitm/util/extras.py
@@ -1,5 +1,5 @@
 r'''
-Copyright 2014 Google Inc. All rights reserved.
+Copyright 2015 Google Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,11 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-import routing
-from ca import CertificateAuthority
-from ip import get_interface_addresses
-from constant import Constants
-from socket import close_quietly
-import vuln
-import http
-import extras
+import os
+
+extras_dir = None
+
+def get_extras_path(file_path):
+    """ Return a full path to file_path in the extras directory."""
+    if extras_dir is None:
+        return file_path
+    return os.path.join(extras_dir, file_path)


### PR DESCRIPTION
This (finally) adds support for a configurable directory for all the extra files used by ngtf and its handlers, set by -x/--extrasdir.

Additionally improve the handling of some of the pyopenssl files since it handles non-existent dhparams poorly.