### PR TITLE
Add precondition checks to handlers

### DIFF
--- a/nogotofail/mitm/__main__.py
+++ b/nogotofail/mitm/__main__.py
@@ -32,6 +32,7 @@ import sys
 from nogotofail.mitm.blame import Server as AppBlameServer
 from nogotofail.mitm.connection import Server, RedirectConnection, SocksConnection, TproxyConnection
 from nogotofail.mitm.connection import handlers
+from nogotofail.mitm.connection.handlers import preconditions
 from nogotofail.mitm.looper import MitmLoop
 from nogotofail.mitm.util import routing, extras
 
@@ -297,7 +298,9 @@ def run():
     selector = build_selector(args.all)
     attack_cls = [handlers.connection.handlers.map[name]
                   for name in args.attacks]
+    attack_cls = preconditions.filter_preconditions(attack_cls, logger)
     data_cls = [handlers.data.handlers.map[name] for name in args.data]
+    data_cls = preconditions.filter_preconditions(data_cls, logger)
     ssl_selector = build_ssl_selector(attack_cls, args.probability, args.all)
     data_selector = build_data_selector(data_cls, args.all, prob_attack=args.probability)
 

--- a/nogotofail/mitm/blame/app_blame.py
+++ b/nogotofail/mitm/blame/app_blame.py
@@ -23,6 +23,7 @@ import time
 import urllib
 
 from nogotofail.mitm.connection import handlers
+from nogotofail.mitm.connection.handlers import preconditions
 from nogotofail.mitm.util import close_quietly
 
 Application = namedtuple("Application", ["package", "version"])
@@ -255,17 +256,18 @@ class Client(object):
         if "Attacks" in headers:
             attacks = headers["Attacks"].split(",")
             attacks = map(str.strip, attacks)
-            client_info["Attacks"] = [
+            client_info["Attacks"] = preconditions.filter_preconditions([
                     handlers.connection.handlers.map[attack] for attack in attacks
-                    if attack in handlers.connection.handlers.map]
+                    if attack in handlers.connection.handlers.map])
 
         if "Data-Attacks" in headers:
             attacks = headers["Data-Attacks"].split(",")
             attacks = map(str.strip, attacks)
-            client_info["Data-Attacks"] = [handlers.data.handlers.map[attack]
+            client_info["Data-Attacks"] = preconditions.filter_preconditions(
+                    [handlers.data.handlers.map[attack]
                     for attack in attacks
                     if attack in
-                    handlers.data.handlers.map]
+                    handlers.data.handlers.map])
 
         # Store the raw headers as well in case a handler needs something the
         # client sent in an additional header

--- a/nogotofail/mitm/connection/handlers/__init__.py
+++ b/nogotofail/mitm/connection/handlers/__init__.py
@@ -16,3 +16,4 @@ limitations under the License.
 import base
 import connection
 import data
+import preconditions

--- a/nogotofail/mitm/connection/handlers/base.py
+++ b/nogotofail/mitm/connection/handlers/base.py
@@ -13,8 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
+
 class BaseHandler(object):
 
+    # The string used to reference this handler. This will be shown in logs and --help
+    name = "handler"
     # Human readable description of what this handler does.
     # Should describe things like attacks
     description = "Basic connection handler. Does nothing but bridge traffic."
@@ -24,12 +27,6 @@ class BaseHandler(object):
     def __init__(self, connection):
         self.connection = connection
 
-    @property
-    def name(self):
-        """Returns the string used to describe this handler.
-        """
-        return self.__class__.__name__
-
     def on_request(self, request):
         """Called when the client sends a request to the server.
 
@@ -37,6 +34,18 @@ class BaseHandler(object):
         Returns the data to send to the server.
         """
         return request
+
+    @staticmethod
+    def check_precondition():
+        """Check if the handler is able to be used in the current run of nogotofail.
+        This should ensure that any required files exist and similar preconditions
+        to the handler being used.
+
+        Returns tuple (precondition_success, error_message)
+        precondition_success: if all preconditions are met
+        error_message: message to be logged explaining the failure if precondition_success is False.
+        """
+        return True, ""
 
     def on_inject_request(self, request):
         """Called when a handler is injecting a request to the server.

--- a/nogotofail/mitm/connection/handlers/connection/invalidhostname.py
+++ b/nogotofail/mitm/connection/handlers/connection/invalidhostname.py
@@ -16,17 +16,19 @@ limitations under the License.
 from nogotofail.mitm.connection.handlers.connection import SelfSignedMITM
 from nogotofail.mitm.connection.handlers.connection import handlers
 from nogotofail.mitm.connection.handlers.store import handler
+from nogotofail.mitm.connection.handlers import preconditions
 from nogotofail.mitm import util
 
 
 @handler(handlers, default=True)
+@preconditions.requires_files(files=["trusted-cert.pem"])
 class InvalidHostnameMITM(SelfSignedMITM):
 
     name = "invalidhostname"
     description = (
         "Attempts to MiTM using a valid certificate for another domain."
         " NOTE: requires ./trusted-cert.pem have a valid cert and private key")
-    certificate_file = "./trusted-cert.pem"
+    certificate_file = "trusted-cert.pem"
     vuln = util.vuln.VULN_TLS_INVALID_HOSTNAME
 
     @property

--- a/nogotofail/mitm/connection/handlers/connection/selfsigned.py
+++ b/nogotofail/mitm/connection/handlers/connection/selfsigned.py
@@ -15,6 +15,7 @@ limitations under the License.
 '''
 import logging
 from nogotofail.mitm import util
+from nogotofail.mitm.connection.handlers import preconditions
 from nogotofail.mitm.connection.handlers.connection import LoggingHandler
 from nogotofail.mitm.connection.handlers.connection import handlers
 from nogotofail.mitm.connection.handlers.store import handler
@@ -86,6 +87,7 @@ class SelfSignedMITM(LoggingHandler):
         return self.certificate
 
 @handler(handlers, default=True)
+@preconditions.requires_files(files=["superfish.pem"])
 class SuperFishMITM(SelfSignedMITM):
     name = "superfishmitm"
     description = "Attempt a MiTM using the compromised superfish MITM CA"

--- a/nogotofail/mitm/connection/handlers/data/http.py
+++ b/nogotofail/mitm/connection/handlers/data/http.py
@@ -15,6 +15,7 @@ limitations under the License.
 '''
 import logging
 from nogotofail.mitm import util
+from nogotofail.mitm.connection.handlers import preconditions
 from nogotofail.mitm.connection.handlers.data import handlers
 from nogotofail.mitm.connection.handlers.data import ClientReportDetection
 from nogotofail.mitm.connection.handlers.data import DataHandler
@@ -397,6 +398,7 @@ class SSLStrip(_ResponseReplacement):
 
 
 @handler(handlers)
+@preconditions.requires_files(files=["replace.png"])
 class ImageReplacement(_ResponseReplacement):
     """Replace images downloaded over HTTP with replace.png.
     Useful for detecting mixed content and a bit of a laugh.

--- a/nogotofail/mitm/connection/handlers/preconditions.py
+++ b/nogotofail/mitm/connection/handlers/preconditions.py
@@ -1,0 +1,64 @@
+r'''
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+import os
+from nogotofail.mitm.util import extras
+
+def filter_preconditions(classes, logger=None):
+    """Filter handlers whose preconditions are not met
+
+    classes: list of nogotofail handler classes to filter
+    logger: logging.Logger to optionally log the failure message of handlers whose preconditions are not met.
+    Returns list of classes whose preconditions are met
+    """
+    filtered = []
+    for cls in classes:
+        status, message = cls.check_precondition()
+        if status:
+            filtered.append(cls)
+        elif logger is not None:
+            logger.warning("Disabling handler %s because preconditions not met: %s.", cls.name, message)
+    return filtered
+
+def _build_precondition_join_fn(cls, fn):
+    """Build a check_precondition function that uses both the old precondition check as well as the new function fn
+
+    cls: class whose check_precondition should be used as a base
+    fn: check_precondition function to check
+    Returns a function that can replace a handler check_precondition method
+    """
+    old_precondition = cls.check_precondition
+    def check_precondition():
+        result, message = fn()
+        if not result:
+            return result, message
+        return old_precondition()
+    return staticmethod(check_precondition)
+
+def requires_files(files):
+    """Decorator for creating a handler that requies files be present in the extras dir in order to run
+
+    files: required files to be present for the handler to be available
+    """
+    def check_files_precondition():
+        for file in files:
+            if not os.path.exists(extras.get_extras_path(file)):
+                return False, "required file %s not found" % (file)
+        return True, ""
+    def wrapper(cls):
+        cls.check_precondition = _build_precondition_join_fn(cls, check_files_precondition)
+        return cls
+    return wrapper


### PR DESCRIPTION
Add the new handler static method check_precondition which if False
will cause the handler to not be used even if explicitly specified. This
allows for checking for required files or other required extra things
that handlers may require.

Includes a helper decorator
@preconditions.requires_files(files) for handlers that require files to
be present in the extras dir.

More preconditions will probably come later like requiring a library or a binary in path, etc.