### PR TITLE
Enable Bazel to build nogotofail Android app.

### DIFF
--- a/nogotofail/clients/android/.gitignore
+++ b/nogotofail/clients/android/.gitignore
@@ -1,2 +1,6 @@
 bin
 gen
+
+# Bazel
+bazel-*
+WORKSPACE

--- a/nogotofail/clients/android/BUILD
+++ b/nogotofail/clients/android/BUILD
@@ -1,0 +1,11 @@
+android_binary(
+    name = "nogotofail",
+    custom_package = "net.nogotofail",
+    srcs = glob([
+        "src/**/*.java",
+    ]),
+    resource_files = glob([
+        "res/**/*",
+    ]),
+    manifest = "AndroidManifest.xml",
+)


### PR DESCRIPTION
Prerequisites:
1. Bazel (http://bazel.io/)
2. WORKSPACE in this directory or any parent ones.
3. WORKSPACE must declare paths to Bazel's android_tools
   and to the Android SDK.

Building:
$ bazel build :nogotofail

Installing using Bazel:

$ bazel mobile-install :nogotofail

Installing manually (assuming WORKSPACE is in this directory):
$ adb install -r -g bazel-bin/nogotofail.apk

Sample WORKSPACE file:

android_local_tools_repository(
    name="android_tools",
    path="~/projects/bazel-github")

android_sdk_repository(
    name="androidsdk",
    path="~/android/android-sdk-linux",
    api_level=23,
    build_tools_version="23.0.0")