### PR TITLE
Add a TLS Record base handler

### DIFF
--- a/nogotofail/mitm/connection/connection.py
+++ b/nogotofail/mitm/connection/connection.py
@@ -360,7 +360,7 @@ class BaseConnection(object):
         Returns if client_request was used(and should not be sent to the server)
         """
         # check for a TLS Client Hello
-        record = tls.parse_tls(client_request)
+        record, ignored = tls.parse_tls(client_request)
         client_hello = None
         if record:
             first = record.messages[0]

--- a/nogotofail/mitm/connection/handlers/connection/ccs.py
+++ b/nogotofail/mitm/connection/handlers/connection/ccs.py
@@ -42,7 +42,7 @@ class EarlyCCS(LoggingHandler):
         if not self.ssl or self.bridge:
             return request
         try:
-            record, size = TlsRecord.from_stream(request)
+            record, remaining = tls.parse_tls(request)
             message = record.messages[0]
             if not self.clienthello_handled:
                 self.clienthello_handled = True

--- a/nogotofail/mitm/connection/handlers/connection/serverkeyreplace.py
+++ b/nogotofail/mitm/connection/handlers/connection/serverkeyreplace.py
@@ -18,6 +18,7 @@ from nogotofail.mitm import util
 from nogotofail.mitm.connection.handlers.connection import LoggingHandler
 from nogotofail.mitm.connection.handlers.connection import handlers
 from nogotofail.mitm.connection.handlers.store import handler
+from nogotofail.mitm.util.tls import tls
 from nogotofail.mitm.util.tls.types import Alert, Extension, HandshakeMessage, OpaqueMessage, TlsRecord
 from nogotofail.mitm.event import connection
 
@@ -56,7 +57,7 @@ class ServerKeyReplacementMITM(LoggingHandler):
         if not self.ssl:
             return request
         try:
-            record, size = TlsRecord.from_stream(request)
+            record, remaining = tls.parse_tls(request)
             message = record.messages[0]
             if not self.clienthello_adjusted:
                 self.clienthello_adjusted = True
@@ -124,9 +125,10 @@ class ServerKeyReplacementMITM(LoggingHandler):
         self.buffer = ""
         # Tamper with the ServerKeyExchange message.
         try:
-            index = 0
-            while index < len(response):
-                record, size = TlsRecord.from_stream(response[index:])
+            remaining = response
+            new_response = ""
+            while remaining:
+                record, remaining = tls.parse_tls(remaining, throw_on_incomplete=True)
                 version = record.version
                 for i, message in enumerate(record.messages):
                     if (isinstance(message, HandshakeMessage)
@@ -134,15 +136,15 @@ class ServerKeyReplacementMITM(LoggingHandler):
                             HandshakeMessage.TYPE.SERVER_KEY_EXCHANGE)):
                         tampered_record_bytes = (
                             self._tamper_with_server_key_exchange(record, i))
-                        response = (response[:index] +
+                        response = (new_response +
                             tampered_record_bytes +
-                            response[index+size:])
+                            remaining)
                         self.signature_tampered = True
                         return response
+                    else:
+                        new_response += record.to_bytes()
 
-                index += size
-
-        except ValueError:
+        except tls.types.TlsNotEnoughDataError:
             # Failed to parse TLS, this is probably due to a short read of a TLS
             # record. Buffer the response to try and get more data.
             self.buffer = response

--- a/nogotofail/mitm/connection/handlers/data/ssl.py
+++ b/nogotofail/mitm/connection/handlers/data/ssl.py
@@ -21,6 +21,88 @@ from nogotofail.mitm.connection.handlers.store import handler
 from nogotofail.mitm.event import connection
 from nogotofail.mitm.util import ssl2, tls, vuln
 
+class _TlsRecordHandler(DataHandler):
+    """Base class for a handler that acts on TlsRecords in a Tls connection.
+
+    Handlers should subclass this and implement on_tls_request and on_tls_response
+    to handle TlsRecords in the connection.
+
+    This class handles buffering and dealing with multiple records in one message
+    and can be used for active or passive handlers as needed.
+    """
+    ssl = False
+    class _TlsRecordBuffer():
+        MAX_BUFFER = 65536
+        def __init__(self):
+            self.buffer = ""
+            self.should_buffer = True
+    client_buffer = None
+    server_buffer = None
+
+    def on_tls_request(self, record):
+        """Called when the client sends a tls record to the server
+
+        record: tls.types.TlsRecord the client sent
+        Returns the bytes to be sent in place of the record
+        """
+        return record.to_bytes()
+
+    def on_tls_response(self, record):
+        """Called when the server sends a tls record to the client
+
+        record: tls.types.TlsRecord the client sent
+        Returns the bytes to be sent in place of the record
+        """
+        return record.to_bytes()
+
+    def on_ssl(self, client_hello):
+        self.ssl = True
+        self.client_buffer = _TlsRecordHandler._TlsRecordBuffer()
+        self.server_buffer = _TlsRecordHandler._TlsRecordBuffer()
+
+    def _handle_message(self, message, buffer, record_fn):
+        """Build a response calling record_fn on all the TlsRecords in message
+
+        message: bytes to parse as TlsRecords
+        record_fn: one of on_tls_request, on_tls_response to handle the record
+        Returns tuple containing the bytes to send for all the records handled and any remaining unparsed data
+        """
+        out = ""
+        message = buffer.buffer + message
+        buffer.buffer = ""
+        remaining = message
+        while remaining:
+            record = None
+            try:
+                record, remaining = tls.parse_tls(remaining, throw_on_incomplete=True)
+            except tls.types.TlsNotEnoughDataError:
+                if buffer.should_buffer:
+                    buffer.buffer = remaining
+                    if len(buffer.buffer) >= buffer.MAX_BUFFER:
+                        buffer.buffer = ""
+                return out
+            if not record:
+                return out
+            record_bytes = record_fn(record)
+            # In a passive handler on_tls_* could return None, so make sure not to cause an error
+            # out doesn't matter on a passive handler.
+            if record_bytes:
+                out += record_bytes
+            # Once we read a CHANGE_CIPHER_SPEC stop trying to buffer, its probably encrypted
+            if record.content_type == record.CONTENT_TYPE.CHANGE_CIPHER_SPEC:
+                buffer.should_buffer = False
+        return out
+
+    def on_request(self, request):
+        if not self.ssl:
+            return request
+        return self._handle_message(request, self.client_buffer, self.on_tls_request)
+
+    def on_response(self, response):
+        if not self.ssl:
+            return response
+        return self._handle_message(response, self.server_buffer, self.on_tls_response)
+
 @handler.passive(handlers)
 class InsecureCipherDetectionHandler(DataHandler):
     name = "insecurecipherdetection"

--- a/nogotofail/mitm/util/tls/__init__.py
+++ b/nogotofail/mitm/util/tls/__init__.py
@@ -13,5 +13,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-from tls import parse_tls
 import types
+from tls import parse_tls

--- a/nogotofail/mitm/util/tls/types/errors.py
+++ b/nogotofail/mitm/util/tls/types/errors.py
@@ -1,0 +1,33 @@
+r'''
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+class TlsNotEnoughDataError(Exception):
+    """Error in TLS parsing where the TLS record is so far valid but incomplete"""
+    pass
+
+class TlsRecordIncompleteError(TlsNotEnoughDataError):
+    """Error for when a TLS Record appears valid but is not enough data is present to parse
+    the record"""
+    def __init__(self, data_available, record_size):
+        self.data_available = data_available
+        self.record_size = record_size
+
+class TlsMessageFragmentedError(TlsNotEnoughDataError):
+    """Error for when not enough data is present to parse a TLS message because of
+    fragmentation"""
+    def __init__(self, fragment_data, data_consumed):
+        self.fragment_data = fragment_data
+        self.data_consumed = data_consumed

--- a/nogotofail/mitm/util/tls/types/record.py
+++ b/nogotofail/mitm/util/tls/types/record.py
@@ -16,6 +16,7 @@ limitations under the License.
 from nogotofail.mitm.util import Constants
 from nogotofail.mitm.util.tls.types import parse
 from nogotofail.mitm.util.tls.types import HandshakeMessage, Version, ChangeCipherSpec, Alert
+from nogotofail.mitm.util.tls.types import TlsRecordIncompleteError, TlsMessageFragmentedError, TlsNotEnoughDataError
 import base64
 import struct
 
@@ -46,34 +47,50 @@ class TlsRecord(object):
         self.messages = messages
 
     @staticmethod
-    def from_stream(body):
+    def from_stream(body, previous_fragment_data=""):
         # Parse the TLS Record
         content_type, version_major, version_minor, length = (
             struct.unpack_from("!BBBH", body, 0))
+        # Sanity checks
+        if version_major != 3 or version_minor > 3:
+            raise ValueError("Bad TLS Version for SSL3-TLS1.2 parsing")
+        if content_type not in name_map:
+            raise ValueError("Unknown content type %d" % content_type)
+
         fragment = body[5:5 + length]
-        # Sanity check
-        if length != len(fragment):
-            raise ValueError("Not enough data in fragment")
-        # Check this is a Handshake message
+        original_fragment = fragment
+        # Merge in any old fragmented data
+        fragment = previous_fragment_data + fragment
+        if len(fragment) < length:
+            raise TlsRecordIncompleteError(len(fragment), length)
+        # Start parsing the objects from the record
         type = TlsRecord.type_map.get(content_type, OpaqueFragment)
         objs = []
-        if fragment == "":
-            obj, size = type.from_stream(fragment)
-            objs.append(obj)
+        try:
+            if fragment == "":
+                obj, size = type.from_stream(fragment)
+                objs.append(obj)
 
-        while fragment != "":
-            obj, size = type.from_stream(fragment)
-            objs.append(obj)
-            fragment = fragment[size:]
+            while fragment != "":
+                obj, size = type.from_stream(fragment)
+                objs.append(obj)
+                fragment = fragment[size:]
+        except TlsNotEnoughDataError:
+            # In the event of not enough data throw what we have up to a higher
+            # level
+            raise TlsMessageFragmentedError(original_fragment, 5 + length)
         return TlsRecord(content_type, Version(version_major, version_minor),
                          objs), 5 + length
 
-    def to_bytes(self):
+    def to_bytes(self, max_fragment_size = 2 ** 12):
         bytes = "".join([message.to_bytes() for message in self.messages])
-        return (struct.pack("B", self.content_type)
-                + self.version.to_bytes()
-                + struct.pack("!H", len(bytes))
-                + bytes)
+        # Fragment the record as needed
+        num_fragments = len(bytes)/max_fragment_size
+        fragments = [bytes[i: i + max_fragment_size] for i in range (0, len(bytes), max_fragment_size)]
+        return "".join([(struct.pack("B", self.content_type)
+                    + self.version.to_bytes()
+                    + struct.pack("!H", len(fragment))
+                    + fragment) for fragment in fragments])
 
     def __str__(self):
         return ("TLS Record %s %s (%d)"

--- a/nogotofail/test/__init__.py
+++ b/nogotofail/test/__init__.py
@@ -1,5 +1,5 @@
 r'''
-Copyright 2014 Google Inc. All rights reserved.
+Copyright 2015 Google Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,14 +13,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-import parse
-from errors import TlsNotEnoughDataError, TlsRecordIncompleteError, TlsMessageFragmentedError
-from cipher import Cipher
-from compression_method import CompressionMethod
-from simple import Version, Random
-from extension import Extension
-from handshake import ClientHello, ServerHello, Certificate, ServerHelloDone, HandshakeMessage, OpaqueMessage
-from change_cipher_spec import ChangeCipherSpec
-from alert import Alert
-
-from record import TlsRecord

--- a/nogotofail/test/mitm/__init__.py
+++ b/nogotofail/test/mitm/__init__.py
@@ -1,5 +1,5 @@
 r'''
-Copyright 2014 Google Inc. All rights reserved.
+Copyright 2015 Google Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,14 +13,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-import parse
-from errors import TlsNotEnoughDataError, TlsRecordIncompleteError, TlsMessageFragmentedError
-from cipher import Cipher
-from compression_method import CompressionMethod
-from simple import Version, Random
-from extension import Extension
-from handshake import ClientHello, ServerHello, Certificate, ServerHelloDone, HandshakeMessage, OpaqueMessage
-from change_cipher_spec import ChangeCipherSpec
-from alert import Alert
-
-from record import TlsRecord

--- a/nogotofail/test/mitm/util/__init__.py
+++ b/nogotofail/test/mitm/util/__init__.py
@@ -1,5 +1,5 @@
 r'''
-Copyright 2014 Google Inc. All rights reserved.
+Copyright 2015 Google Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,14 +13,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-import parse
-from errors import TlsNotEnoughDataError, TlsRecordIncompleteError, TlsMessageFragmentedError
-from cipher import Cipher
-from compression_method import CompressionMethod
-from simple import Version, Random
-from extension import Extension
-from handshake import ClientHello, ServerHello, Certificate, ServerHelloDone, HandshakeMessage, OpaqueMessage
-from change_cipher_spec import ChangeCipherSpec
-from alert import Alert
-
-from record import TlsRecord

--- a/nogotofail/test/mitm/util/tls/__init__.py
+++ b/nogotofail/test/mitm/util/tls/__init__.py
@@ -1,5 +1,5 @@
 r'''
-Copyright 2014 Google Inc. All rights reserved.
+Copyright 2015 Google Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,14 +13,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-import parse
-from errors import TlsNotEnoughDataError, TlsRecordIncompleteError, TlsMessageFragmentedError
-from cipher import Cipher
-from compression_method import CompressionMethod
-from simple import Version, Random
-from extension import Extension
-from handshake import ClientHello, ServerHello, Certificate, ServerHelloDone, HandshakeMessage, OpaqueMessage
-from change_cipher_spec import ChangeCipherSpec
-from alert import Alert
-
-from record import TlsRecord

--- a/nogotofail/test/mitm/util/tls/test_handshake.py
+++ b/nogotofail/test/mitm/util/tls/test_handshake.py
@@ -1,0 +1,104 @@
+r'''
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+import unittest
+from nogotofail.mitm.util import tls
+
+# Basic client hello from `openssl s_client -tls1_2 -cipher HIGH`
+BASIC_HELLO = ("FgMBASIBAAEeAwOVqPajcw+kjqqu6OY0g/k/UqYSjwdXHdiYwhfn+ZpNPgAAiMAwwCzAKMAkwBTA\n"
+               "CgCjAJ8AawBqADkAOACIAIfAGQCnAG0AOgCJwDLALsAqwCbAD8AFAJ0APQA1AITAEsAIABYAE8AX\n"
+               "ABvADcADAArAL8ArwCfAI8ATwAkAogCeAGcAQAAzADIARQBEwBgApgBsADQARsAxwC3AKcAlwA7A\n"
+               "BACcADwALwBBAP8BAABtAAsABAMAAQIACgA0ADIADgANABkACwAMABgACQAKABYAFwAIAAYABwAU\n"
+               "ABUABAAFABIAEwABAAIAAwAPABAAEQAjAAAADQAgAB4GAQYCBgMFAQUCBQMEAQQCBAMDAQMCAwMC\n"
+               "AQICAgMADwABAQ==\n").decode("base64")
+
+
+# BASIC_HELLO split into two fragments
+FRAGMENTED_BASIC_HELLO = (
+        "FgMBADIBAAEeAwOVqPajcw+kjqqu6OY0g/k/UqYSjwdXHdiYwhfn+ZpNPgAAiMAwwCzAKMAkwBYD\n"
+        "AQDwFMAKAKMAnwBrAGoAOQA4AIgAh8AZAKcAbQA6AInAMsAuwCrAJsAPwAUAnQA9ADUAhMASwAgA\n"
+        "FgATwBcAG8ANwAMACsAvwCvAJ8AjwBPACQCiAJ4AZwBAADMAMgBFAETAGACmAGwANABGwDHALcAp\n"
+        "wCXADsAEAJwAPAAvAEEA/wEAAG0ACwAEAwABAgAKADQAMgAOAA0AGQALAAwAGAAJAAoAFgAXAAgA\n"
+        "BgAHABQAFQAEAAUAEgATAAEAAgADAA8AEAARACMAAAANACAAHgYBBgIGAwUBBQIFAwQBBAIEAwMB\n"
+        "AwIDAwIBAgICAwAPAAEB\n").decode("base64")
+
+class TestClientHelloParsing(unittest.TestCase):
+
+    def check_basic_hello_record(self, record):
+        # Verify parsing was successful
+        self.assertIsNotNone(record, "parse_tls failed")
+
+        # Check the record is sane
+        self.assertEqual(record.version.major, 3)
+        self.assertEqual(record.version.minor, 1)
+        self.assertEqual(record.content_type, record.CONTENT_TYPE.HANDSHAKE)
+        self.assertEqual(len(record.messages), 1)
+
+        # Check the HandshakeMessage
+        message = record.messages[0]
+        self.assertIsInstance(message, tls.types.HandshakeMessage)
+        self.assertEqual(message.type, message.TYPE.CLIENT_HELLO)
+
+        # Check the ClientHello itself
+        hello = message.obj
+        self.assertIsInstance(hello, tls.types.ClientHello)
+        self.assertEqual(hello.version.major, 3)
+        self.assertEqual(hello.version.minor, 3)
+        self.assertEqual(hello.session_id, [])
+        self.assertEqual(hello.random.bytes,
+                "730fa48eaaaee8e63483f93f52a6128f07571dd898c217e7f99a4d3e".decode("hex"))
+        # TODO: Check that the contents are correct/correct order
+        self.assertEqual(len(hello.ciphers), 68)
+        self.assertEqual(len(hello.extensions), 5)
+        for key in [35, 10, 11, 13, 15]:
+            self.assertTrue(key in hello.extensions)
+
+    def test_parse_basic_hello(self):
+        record, remaining = tls.parse_tls(BASIC_HELLO)
+        self.assertIsNotNone(record)
+        self.assertEquals(remaining, "")
+        self.check_basic_hello_record(record)
+
+    def test_parse_basic_hello_extra(self):
+        extra_bytes = "\x11\x22\x33\x44"
+        record, remaining = tls.parse_tls(BASIC_HELLO + extra_bytes)
+        self.assertIsNotNone(record)
+        self.assertEquals(remaining, extra_bytes)
+        self.check_basic_hello_record(record)
+
+    def test_fragmented_basic_hello(self):
+        record, remaining = tls.parse_tls(FRAGMENTED_BASIC_HELLO)
+        self.assertIsNotNone(record)
+        self.assertEquals(remaining, "")
+        self.check_basic_hello_record(record)
+
+    def test_fragmenting(self):
+        record, remaining = tls.parse_tls(BASIC_HELLO)
+        self.assertIsNotNone(record)
+        self.assertEquals(remaining, "")
+        # Fragment on purpose
+        bytes = record.to_bytes(max_fragment_size=50)
+        # sanity check this parses back out
+        parsed_rec, remaining = tls.parse_tls(bytes)
+        self.assertIsNotNone(parsed_rec)
+        self.assertEqual(remaining, "")
+        self.check_basic_hello_record(parsed_rec)
+
+        # Now check that they got split by parsing for only one record
+        with self.assertRaises(tls.types.TlsNotEnoughDataError):
+            tls.types.TlsRecord.from_stream(bytes)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We currently have too many handlers implementing their own record parsing and buffering. This PR adds a base class they can use to skip that and focus only on the records.

Additionally, to make this feasible TLS parsing was improved to properly support fragmented records and more cleanly support incomplete reads of records.
