### PR TITLE
Add reverse proxy mode

### DIFF
--- a/nogotofail/mitm/connection/__init__.py
+++ b/nogotofail/mitm/connection/__init__.py
@@ -13,6 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-from connection import RedirectConnection, SocksConnection, TproxyConnection
+from connection import RedirectConnection, SocksConnection, TproxyConnection, ReverseProxyConnection
 from server import Server
 import handlers


### PR DESCRIPTION
Adds a reverse proxy mode whereby clients connect directly to the
reverse proxy, and the proxy forwards the connection to a target host
and port specified on the command line or config. For example:

```
$ python -m nogotofail.mitm -A invalidhostname \
  --mode reverse --port 443 --serverssl server.crt \
  --target_addr www.example.com --target_port 443
```

The reverse proxy mode makes it trivial to test a client that always
connects to a specific server port, as it doesn't require socks or
transparent proxy.

That said, the mode has some limitations. It cannot be used in cases
where the client needs to connect to multiple servers/ports. Also, it
doesn't rewrite HTTP headers, e.g. Host, so the values may be incorrect
when received by the real server, and when responses are received by the
client.
