### PR TITLE
Include seconds in notAfter date

### DIFF
--- a/nogotofail/mitm/util/ca.py
+++ b/nogotofail/mitm/util/ca.py
@@ -46,7 +46,7 @@ class CertificateAuthority(object):
         self.cert.set_serial_number(1)
         self.cert.get_subject().CN = 'ca.nogotofail'
         self.cert.set_notBefore("19300101000000+0000")
-        self.cert.set_notAfter("203012310000+0000")
+        self.cert.set_notAfter("20301231000000+0000")
         self.cert.set_issuer(self.cert.get_subject())
         self.cert.set_pubkey(self.key)
         self.cert.add_extensions([
@@ -95,7 +95,7 @@ class CertificateAuthority(object):
         cert.set_serial_number(random.randint(0, 2**20))
         # Use a huge range so we dont have to worry about bad clocks
         cert.set_notBefore("19300101000000+0000")
-        cert.set_notAfter("203012310000+0000")
+        cert.set_notAfter("20301231000000+0000")
         cert.set_issuer(self.cert.get_subject())
         if san:
             cert.add_extensions([san])


### PR DESCRIPTION
Nogotofail omitted the seconds portion of the notAfter date, which
causes openjdk 1.8 to fail to parse the string as a GeneralizedTime[1]:

```
java.io.IOException: Parse Generalized time, invalid offset
```

This can lead to false negatives in otherwise vulnerable SSL clients.

Since notBefore includes seconds, include them for notAfter for greater
compatibility. This affects both the selfsigned and invalidhostname
attacks.

[1] https://github.com/openjdk-mirror/jdk/blob/c5294eda494101e62dc4c0eaa946ebe9ce60cd6b/src/share/classes/sun/security/util/DerInputBuffer.java#L392-L396
