### PR TITLE
Fix record building in serverkeyreplace

### DIFF
--- a/nogotofail/mitm/connection/handlers/connection/serverkeyreplace.py
+++ b/nogotofail/mitm/connection/handlers/connection/serverkeyreplace.py
@@ -141,8 +141,7 @@ class ServerKeyReplacementMITM(LoggingHandler):
                             remaining)
                         self.signature_tampered = True
                         return response
-                    else:
-                        new_response += record.to_bytes()
+                new_response += record.to_bytes()
 
         except tls.types.TlsNotEnoughDataError:
             # Failed to parse TLS, this is probably due to a short read of a TLS


### PR DESCRIPTION
In the refactor of TLSHandlers the logic for splitting uneeded records
out in on_response was done incorrect and so would add an entire copy of
the TLS record for each message in the record before the
ServerKeyExchange

Fixes #107
