### PR TITLE
Harden OpenVPN configuration

### DIFF
--- a/docs/gce/nogotofail.ovpn.template
+++ b/docs/gce/nogotofail.ovpn.template
@@ -14,3 +14,12 @@ persist-tun
 persist-key
 
 comp-lzo
+
+# Accept only server certificates which are whitelisted (via Key Usage and Extended Key Usage) for
+# server authentication
+remote-cert-tls server
+
+# Symmetric tunnel crypto config
+auth SHA256
+cipher AES-128-CBC
+keysize 128

--- a/docs/gce/openvpn-client-cert-extfile.cfg
+++ b/docs/gce/openvpn-client-cert-extfile.cfg
@@ -1,0 +1,2 @@
+keyUsage = digitalSignature, keyAgreement
+extendedKeyUsage = clientAuth

--- a/docs/gce/openvpn-server-cert-extfile.cfg
+++ b/docs/gce/openvpn-server-cert-extfile.cfg
@@ -1,0 +1,2 @@
+keyUsage = digitalSignature, keyAgreement
+extendedKeyUsage = serverAuth

--- a/docs/gce/openvpn.conf
+++ b/docs/gce/openvpn.conf
@@ -58,3 +58,11 @@ cert /etc/openvpn/server_cert.pem
 key /etc/openvpn/server_key.pem
 
 dh /etc/openvpn/dhparam2048.pem
+
+# ECDHE isn't yet supported by OpenVPN (as of 2.3)...
+tls-cipher DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES128-SHA256,DHE-RSA-AES128-SHA
+
+# Symmetric tunnel crypto config
+auth SHA256
+cipher AES-128-CBC
+keysize 128

--- a/docs/gce/setup_openvpn.sh
+++ b/docs/gce/setup_openvpn.sh
@@ -20,13 +20,13 @@ echo "Generating server public key pair and certificate..."
 openssl genrsa -out $CONFIG_DIR/server_key.pem 2048
 openssl req -new -key $CONFIG_DIR/server_key.pem -out $CONFIG_DIR/server_csr.pem -subj '/CN=server.vpn.nogotofail'
 chmod 600 $CONFIG_DIR/server_key.pem
-openssl x509 -req -in $CONFIG_DIR/server_csr.pem -CA $CONFIG_DIR/ca_cert.pem -CAkey $CONFIG_DIR/ca_key.pem -CAcreateserial -out $CONFIG_DIR/server_cert.pem -sha256 -days 365
+openssl x509 -req -in $CONFIG_DIR/server_csr.pem -CA $CONFIG_DIR/ca_cert.pem -CAkey $CONFIG_DIR/ca_key.pem -CAcreateserial -out $CONFIG_DIR/server_cert.pem -sha256 -days 365 -extfile openvpn-server-cert-extfile.cfg
 rm $CONFIG_DIR/server_csr.pem
 
 echo "Generating client public key pair and certificate..."
 openssl genrsa -out $CONFIG_DIR/client_key.pem 2048
 openssl req -new -key $CONFIG_DIR/client_key.pem -out $CONFIG_DIR/client_csr.pem -subj '/CN=client.vpn.nogotofail'
-openssl x509 -req -in $CONFIG_DIR/client_csr.pem -CA $CONFIG_DIR/ca_cert.pem -CAkey $CONFIG_DIR/ca_key.pem -CAcreateserial -out $CONFIG_DIR/client_cert.pem -sha256 -days 365
+openssl x509 -req -in $CONFIG_DIR/client_csr.pem -CA $CONFIG_DIR/ca_cert.pem -CAkey $CONFIG_DIR/ca_key.pem -CAcreateserial -out $CONFIG_DIR/client_cert.pem -sha256 -days 365 -extfile openvpn-client-cert-extfile.cfg
 rm $CONFIG_DIR/client_csr.pem
 
 openssl dhparam 2048 > $CONFIG_DIR/dhparam2048.pem


### PR DESCRIPTION
This switches OpenVPN tunnel from Blowfish with SHA-1 HMAC to
128-bit AES with SHA-256 HMAC.

Moreover, client configuration now requires that server certificate is
permitted to be used for server authentication (as signalled by the
certificate's Key Usage and Extended Key Usage extensions). This is to
prevent one client of the server from being able to use its client
certificate to MiTM other clients of the server. This is needed
because in the current setup server and client certs are issued from
the same CA.