### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#nogotofail
+# nogotofail
 
 
 Nogotofail is a network security testing tool designed to help developers and
@@ -7,18 +7,18 @@ cleartext traffic on devices and applications in a flexible, scalable, powerful 
 It includes testing for common SSL certificate verification issues, HTTPS and TLS/SSL
 library bugs, SSL and STARTTLS stripping issues, cleartext issues, and more.
 
-##Design
+## Design
 Nogotofail is composed of an on-path network MiTM and optional clients for the devices being tested.
 See [docs/design.md](docs/design.md) for the overview and design goals of nogotofail.
 
-##Dependencies
+## Dependencies
 Nogotofail depends only on Python 2.7 and pyOpenSSL>=0.13. The MiTM is designed to work on Linux
 machines and the transparent traffic capture modes are Linux specific and require iptables as well.
 
 Additionally the Linux client depends on [psutil](https://pypi.python.org/pypi/psutil).
 
-##Getting started
+## Getting started
 See [docs/getting_started.md](docs/getting_started.md) for setup and a walkthrough of nogotofail.
 
-##Discussion
+## Discussion
 For discussion please use our [nogotofail Google Group](https://groups.google.com/forum/#!forum/nogotofail).

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,4 +1,4 @@
-#Design Goals
+# Design Goals
 
 
 Nogotofail was designed to be an automated, powerful, flexible and scalable tool
@@ -20,13 +20,13 @@ such that it does not get in the way of using devices as normal. Tests
 that are destructive are by default run only when necessary and with low
 probability.
 
-##The building blocks of nogotofail
+## The building blocks of nogotofail
 
 Nogotofail is centered around an on path man in the middle tool written in python
 with an optional client application to provide additional attribution and
 configuration support.
 
-###Man in The Middle
+### Man in The Middle
 
 The core of nogotofail is the on path network MiTM named nogotofail.mitm that
 intercepts TCP traffic. It is designed to primarily run on path and centers
@@ -36,7 +36,7 @@ nogotofail is completely port agnostic and instead detects vulnerable traffic
 using DPI instead of based on port numbers. Additionally, because it uses DPI,
 it is capable of testing TLS/SSL traffic in protocols that use STARTTLS.
 
-####Why attack probabilistically?
+#### Why attack probabilistically?
 
 Nogotofail does not destructively attack all TLS/SSL connections it sees because
 such attacks lead to non-vulnerable clients aborting attacked connections. If
@@ -56,15 +56,15 @@ devices we’ve seen tend to work as usual.
 Of course, if you want to test a specific connection aggressively you can push
 the probability up to 100%.
 
-####Protocol sensing
+#### Protocol sensing
 
 Protocol sensing for a TLS/SSL testing tool is critical because only attacking
 traffic on port 443 has two flaws. First, it misses TLS/SSL traffic on
 non-standard ports, and second, it fails to test protocols that use STARTTLS.
 
-###Client *(optional)*
+### Client *(optional)*
 
-####Why have a client?
+#### Why have a client?
 
 When testing on real devices it can be very difficult to determine what component or app made a
 vulnerable connection. Even seeing the contents and the destination isn’t always
@@ -83,7 +83,7 @@ Finally, the client receives notifications of vulnerabilities from the MiTM. Thi
 were issues, and it helps you understand exactly what action triggered the
 vulnerability.
 
-####What the client does
+#### What the client does
 
 The client exists to provide additional details about connections, allow the
 client to configure attack settings, and to be notified when vulnerabilities are

--- a/docs/gce/readme.md
+++ b/docs/gce/readme.md
@@ -1,4 +1,4 @@
-#Nogotofail MiTM on Google Compute Engine VM instance
+# Nogotofail MiTM on Google Compute Engine VM instance
 
 ## Overview
 In this setup, traffic from clients to be MiTM'd is routed through a Google

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,10 +1,10 @@
-#Getting Started
-##Files you’ll need to provide
+# Getting Started
+## Files you’ll need to provide
 
 
 Before running nogotofail there are some files you’ll need to create or provide.
 
-###MiTM Server certificate
+### MiTM Server certificate
 
 
 The connection between clients and the MiTM is protected by a self-signed
@@ -16,7 +16,7 @@ For example the OpenSSL command to generate such a certificate is:
 
     $ openssl req -x509 -newkey rsa:2048 -sha256 -subj "/CN=mitm.nogotofail/" -nodes -keyout server.crt -out server.crt
 
-###Invalid Hostname Certificate
+### Invalid Hostname Certificate
 
 The Invalid hostname attack attempts a MiTM by presenting a trusted certificate
 for another domain name. For example a trusted certificate for evil.com being
@@ -44,13 +44,13 @@ To verify the chain is correct
     $ openssl verify -CApath /etc/ssl/certs/ -untrusted trusted-cert.pem trusted-cert.pem
 You should see OK as the output.
 
-###ImageReplace Image
+### ImageReplace Image
 
 If you decide to use the image replacement data attack you’ll need to provide an image to
 replace with in the form of replace.png in nogotofail.mitm’s working directory.
 We recommend something noticeable that scales well.
 
-##Example Walkthrough
+## Example Walkthrough
 
 
 Here is a quick walkthrough of running and testing the MiTM locally.
@@ -171,7 +171,7 @@ attack for later analysis.
 6. The connection closes
 
 
-###Getting on path
+### Getting on path
 
 
 Now that you’ve set up nogotofail and seen how it runs the next step is to put
@@ -199,7 +199,7 @@ OpenVPN as there is lots of documentation for how to set up an OpenVPN server.
 Our main setup has been OpenVPN running on a Google Compute Engine instance. See instructions in
 [gce/readme.md](gce/readme.md).
 
-####Testing Android
+#### Testing Android
 For testing Android devices we have included our [Android client](/nogotofail/clients/android) ready
 to be imported into Eclipse. You will have to build the app and install it on your test device.
 
@@ -207,7 +207,7 @@ For testing you can use the access point nogotofail setups or on  devices >=JB y
 the OpenVPN setup and a third party VPN application to route your traffic.
 
 
-#####Getting on path on a Linux machine
+##### Getting on path on a Linux machine
 On a Linux machine with the following example topology:
 
 
@@ -237,7 +237,7 @@ Now traffic will be flowing through the MiTM box from the test device to the
 Internet.
 
 
-###Now you’re on path
+### Now you’re on path
 
 
 By default clients connect to the MiTM using hostname mitm.nogotofail
@@ -255,7 +255,7 @@ in [example.conf](example.conf), and run it with `python -m nogotofail.mitm -c <
 If you’re running in an iptables mode you’ll also need to run nogotofail.mitm as
 root so it can set up the routing rules to intercept traffic.
 
-####Useful arguments
+#### Useful arguments
 
 
 
@@ -286,7 +286,7 @@ important ones you’ll want to tweak.
 
  You can see all the options by running `python -m nogotofail.mitm --help`.
 
-#####Logging
+##### Logging
 
 
 Additionally, you will probably want to log to files in addition to stdout.

--- a/docs/mitm.md
+++ b/docs/mitm.md
@@ -1,5 +1,5 @@
-#MiTM Details
-##How MiTM intercepts traffic
+# MiTM Details
+## How MiTM intercepts traffic
 
 Nogotofail currently supports three traffic interception modes that can be
 selected using the --mode option. The tproxy and redirect modes are
@@ -7,49 +7,49 @@ transparent to the client and destination, and are for running nogotofail on-pat
 Note they require the MiTM to be run as root in order to create the iptables
 and routing rules to capture traffic.
 
-###tproxy
+### tproxy
 Tproxy mode uses iptables tproxy and ip mark routing rules to route all traffic
 passing through the device to nogotofail.
 
-###redirect
+### redirect
 Redirect mode uses iptables nat redirection to route all traffic passing
 through the device to nogotofail. Redirect is the older and more tested way of
 routing traffic to nogotofail but has poor IPv6 support, requiring bleeding
 edge iptables and Linux kernel >= 3.7.
 
-###socks
+### socks
 Socks mode has nogotofail listening as a SOCKS5 proxy. Unlike the iptables
 rules this doesn’t require nogotofail to be on path or have root access, but it
 does lose the transparency of those modes.
 
 It is also useful when testing changes to nogotofail locally, as it requires minimal setup.
 
-#Architecture Overview
+# Architecture Overview
 
-##Connections
+## Connections
 Every TCP connection is routed to a nogotofail connection which is responsible
 for bridging traffic, detecting TLS/SSL traffic and sending events to handlers
 which implement attacks and detection.
 
-##Handlers
+## Handlers
 All the actual vulnerability detection is done in small event handlers. In
 nogotofail there are two types of handlers, connection handlers and data
 handlers. You can see all the events handlers receive and their documentation in
 (nogotofail/mitm/connection/handlers/base.py)[nogotofail/mitm/connection/handlers/base.py]
 
-###Connection Handlers
+### Connection Handlers
 Each connection in nogotofail has only one connection handler which is
 responsible for doing connection level testing on TLS/SSL. These are used for
 vulnerabilities like accepting self-signed certificates or heartbleed.
 
-###Data Handlers
+### Data Handlers
 Data handlers are responsible for detecting issues in traffic or modifying
 traffic to test for vulnerabilities. Unlike Connection Handlers each connection
 can have multiple data handlers whose outputs are chained together. These are
 used for vulnerabilities like detecting auth tokens in cleartext or attempting
 ssl stripping attacks.
 
-##Life of a connection
+## Life of a connection
 1. When a connection is first created it selects the initial connection handler and the list of data handler.
 2. Each handler’s on_select method is called.
 3. Once the connection to the remote is successful each handler’s on_establish is called
@@ -58,7 +58,7 @@ ssl stripping attacks.
 6. If a TLS/SSL Client Hello is detected by the connection the connection checks if it should MiTM’d. See ‘on TLS Client Hello’.
 7. When the connection is closed each handler’s on_close is called
 
-###On TLS/SSL Client Hello
+### On TLS/SSL Client Hello
 1. When a TLS/SSL client hello is detected the connection selects a new connection handler for the TLS/SSL connection.
 2. If handler.on_ssl returns False the connection will continue simply bridging traffic as before
 3. Otherwise the connection to the server is wrapped with TLS/SSL and handler.on_certificate is called with the cert presented by the server to generate a certificate to present to the client


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
