### PR TITLE
Simplify IPv6 config

### DIFF
--- a/docs/gce/nogotofail.ovpn.template
+++ b/docs/gce/nogotofail.ovpn.template
@@ -3,8 +3,7 @@ proto udp
 client
 verb 4
 dev tun
-tun-ipv6
-redirect-gateway
+redirect-gateway ipv6
 
 # keepalive 60 120
 ping 60

--- a/docs/gce/openvpn.conf
+++ b/docs/gce/openvpn.conf
@@ -3,6 +3,7 @@ proto udp
 
 dev tun
 server 10.8.0.0 255.255.255.0
+server-ipv6 fd12:3456:789a:bcde::/64
 topology subnet
 
 # Because GCE doesn't support IPv6 we
@@ -10,16 +11,6 @@ topology subnet
 # sends empty replies for AAAA queries for IPv6 addresses.
 # This forces clients to switch to using IPv4 addresses.
 push "dhcp-option DNS 10.8.0.1"
-
-# Blackhole IPv6 traffic because GCE does not support IPv6.
-# This is achieved by making OpenVPN server have a fake IPv6 address
-# (otherwise OpenVPN server will not push IPv6 information to
-# client) and pushing a route to the client to blackhole IPv6 traffic
-# client-side.
-server-ipv6 2001:db8:123::/64
-# OpenVPN 2.3 doesn't work well with IPv6. Push a route to client
-# to blackhole IPv6 traffic on the client.
-push "route-ipv6 2000::/3"
 
 # Enabling floating mode to work around the issue where
 # some clients's source IP+port may change mid-session because


### PR DESCRIPTION
Now that we switched to OpenVPN 2.4, we no longer need the client-side
IPv6 blackholing trick. Remove!